### PR TITLE
讓api回傳中文時不顯示Unicode(PHP5.4以上適用)

### DIFF
--- a/module/mod_ajax.php
+++ b/module/mod_ajax.php
@@ -39,7 +39,7 @@ class mod_ajax{
 
 	function output_json(&$ar)
 	{
-		echo json_encode($ar);
+		echo json_encode($ar, JSON_UNESCAPED_UNICODE);
 		exit(0);
 	}
 

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -219,8 +219,8 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 			}
 			//...
 			$pte_vals['{$PAGENAV}'] .= '[<a onclick="">...</a>]';
-			//最後三頁
 			
+			//最後三頁
 			for($i = $page_end-3; $i < $page_end; $i++){
 				$pageNext = ($i==$next) ? ' rel="next"' : '';
 				if($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -213,10 +213,19 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 				else{
 					$pageNext = ($i==$next) ? ' rel="next"' : '';
 					if(!$adminMode && $i==0) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-					elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL)) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
+					elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL)) //$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
 					else $pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';
 				}
 			}
+			//...
+			$pte_vals['{$PAGENAV}'] .= '[<a onclick="">...</a>]';
+			//最後三頁
+			for($i = $page_end-3; $i < $page_end; $i++){
+				if($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
+			}
+			
+			
+			
 			$pte_vals['{$PAGENAV}'] .= '</td>';
 			if($threads_count > $next * PAGE_DEF){
 				if($adminMode || (STATIC_HTML_UNTIL != -1) && ($next > STATIC_HTML_UNTIL)) $pte_vals['{$PAGENAV}'] .= '<td><form action="'.PHP_SELF.'?page_num='.$next.'" method="post">';

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -233,11 +233,12 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$page_end.'"'.$pageNext.'>'.$page_end.'</a>] ';
 				}elseif($page > $page_end-5 && $page <=$page_end){
-					for($i = $page_end-8;$i < $page_end+1;$i++){				
+					for($i = $page_end-8,$first_page_live = false;$i < $page_end+1;$i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
-							if(!$adminMode && $i==0){
+							if(!$adminMode && !$first_page_live){
+								$first_page_live = true;
 								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
 								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
 							} 

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -211,7 +211,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 			
 			//生成頁數不等於10時,不提供E變態的頁面功能
 			//$len 取代 $page_end , $page_end在使用$page_num當網址時會等同$page
-			$len = $threads_count / PAGE_DEF;
+			$len = ceil($threads_count / PAGE_DEF) -1;
 			if($len < STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
 				for($i = 0; $i < $len; $i++){
 					if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
@@ -236,7 +236,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}elseif($page > $len-5 && $page <= $len){
 					// 尾頁
-					for($i = $len-8, $first_page_live = false; $i < $len+1; $i++){				
+					for($i = $len-9, $first_page_live = false, $len2 = len+1; $i < $len2; $i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
@@ -250,7 +250,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					}				
 				}else{
 					// 中間頁
-					for($i = $page-3, $i_end = $page+4, $first_page_live = false; $i < $i_end;$i++){				
+					for($i = $page-4, $i_end = $page+4, $first_page_live = false; $i < $i_end; $i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
@@ -265,9 +265,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}
-			}			
-			
-			
+			}
 			
 			$pte_vals['{$PAGENAV}'] .= '</td>';
 			if($threads_count > $next * PAGE_DEF){

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -232,7 +232,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
 					}
-					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (0-'.$len.')\', 0);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}elseif($page > $len-5 && $page <= $len){
 					// 尾頁
@@ -243,7 +243,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 							if(!$adminMode && !$first_page_live){
 								$first_page_live = true;
 								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (0-'.$len.')\', 0);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 							} 
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
@@ -257,12 +257,12 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 							if(!$adminMode && !$first_page_live){
 								$first_page_live = true;
 								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (0-'.$len.')\', 0);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 							} 
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
 					}
-					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (0-'.$len.')\', 0);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';					
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}
 			}

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -208,22 +208,57 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 				$pte_vals['{$PAGENAV}'] .= '<div><input type="submit" value="'._T('prev_page').'" /></div></form></td>';
 			}else $pte_vals['{$PAGENAV}'] .= '<td style="white-space: nowrap;">'._T('first_page').'</td>';
 			$pte_vals['{$PAGENAV}'] .= '<td>';
-			for($i = 0, $len = $threads_count / PAGE_DEF; $i < $len; $i++){
-				if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
-				else{
-					$pageNext = ($i==$next) ? ' rel="next"' : '';
-					if(!$adminMode && $i==0) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-					elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL)) //$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
-					else $pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';
-				}
-			}
-			//...
-			$pte_vals['{$PAGENAV}'] .= '[<a onclick="">...</a>]';
 			
-			//最後三頁
-			for($i = $page_end-3; $i < $page_end; $i++){
-				$pageNext = ($i==$next) ? ' rel="next"' : '';
-				if($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
+			//生成頁數不等於10時,不提供E變態的頁面功能
+			if($threads_count / PAGE_DEF > STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
+				for($i = 0, $len = $threads_count / PAGE_DEF; $i < $len; $i++){
+					if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
+					else{
+						$pageNext = ($i==$next) ? ' rel="next"' : '';
+						if(!$adminMode && $i==0) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
+						elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))//$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
+						else $pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';
+					}
+				}			
+			}else{
+				if($page > -1 && $page < 5){
+					for($i = 0;$i < 9;$i++){
+						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
+						else{
+							$pageNext = ($i==$next) ? ' rel="next"' : '';
+							if(!$adminMode && $i==0) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
+							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';					
+						}					
+					}
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$page_end.'"'.$pageNext.'>'.$page_end.'</a>] ';
+				}elseif($page > $page_end-5 && $page <=$page_end){
+					for($i = $page_end-8;$i < $page_end+1;$i++){				
+						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
+						else{
+							$pageNext = ($i==$next) ? ' rel="next"' : '';
+							if(!$adminMode && $i==0){
+								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+							} 
+							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
+						}					
+					}				
+				}else{
+					for($i = 0;$i < 7;$i++){				
+						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
+						else{
+							$pageNext = ($i==$next) ? ' rel="next"' : '';
+							if(!$adminMode && $i==0){
+								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+							} 
+							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
+						}					
+					}
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$page_end.'"'.$pageNext.'>'.$page_end.'</a>] ';
+				}
 			}
 			
 			

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -218,7 +218,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					else{
 						$pageNext = ($i==$next) ? ' rel="next"' : '';
 						if(!$adminMode && $i==0) $pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-						elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))//$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
+						elseif($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ));//$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
 						else $pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';
 					}
 				}			
@@ -236,7 +236,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}elseif($page > $len-5 && $page <= $len){
 					// 尾頁
-					for($i = $len-9, $first_page_live = false, $len2 = len+1; $i < $len2; $i++){				
+					for($i = $len-9, $first_page_live = false, $len2 = $len+1; $i < $len2; $i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -210,7 +210,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 			$pte_vals['{$PAGENAV}'] .= '<td>';
 			
 			//生成頁數不等於10時,不提供E變態的頁面功能
-			if($threads_count / PAGE_DEF > STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
+			if($threads_count / PAGE_DEF < STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
 				for($i = 0, $len = $threads_count / PAGE_DEF; $i < $len; $i++){
 					if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 					else{

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -210,8 +210,10 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 			$pte_vals['{$PAGENAV}'] .= '<td>';
 			
 			//生成頁數不等於10時,不提供E變態的頁面功能
-			if($threads_count / PAGE_DEF < STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
-				for($i = 0, $len = $threads_count / PAGE_DEF; $i < $len; $i++){
+			//$len 取代 $page_end , $page_end在使用$page_num當網址時會等同$page
+			$len = $threads_count / PAGE_DEF;
+			if($len < STATIC_HTML_UNTIL || STATIC_HTML_UNTIL!=10){
+				for($i = 0; $i < $len; $i++){
 					if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 					else{
 						$pageNext = ($i==$next) ? ' rel="next"' : '';
@@ -222,7 +224,7 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 				}			
 			}else{
 				if($page > -1 && $page < 5){
-					for($i = 0;$i < 9;$i++){
+					for($i = 0; $i < 9; $i++){
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
@@ -230,37 +232,40 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.$i.PHP_EXT.'?"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
 					}
-					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
-					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$page_end.'"'.$pageNext.'>'.$page_end.'</a>] ';
-				}elseif($page > $page_end-5 && $page <=$page_end){
-					for($i = $page_end-8,$first_page_live = false;$i < $page_end+1;$i++){				
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
+				}elseif($page > $len-5 && $page <= $len){
+					// 尾頁
+					for($i = $len-8, $first_page_live = false; $i < $len+1; $i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
 							if(!$adminMode && !$first_page_live){
 								$first_page_live = true;
 								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 							} 
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
 					}				
 				}else{
-					for($i = 0;$i < 7;$i++){				
+					// 中間頁
+					for($i = $page-3, $i_end = $page+4, $first_page_live = false; $i < $i_end;$i++){				
 						if($page==$i) $pte_vals['{$PAGENAV}'] .= "[<b>".$i."</b>] ";
 						else{
 							$pageNext = ($i==$next) ? ' rel="next"' : '';
-							if(!$adminMode && $i==0){
+							if(!$adminMode && !$first_page_live){
+								$first_page_live = true;
 								$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF2.'?">0</a>] ';
-								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
+								$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
 							} 
 							elseif($adminMode || (STATIC_HTML_UNTIL != -1))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';					
 						}					
 					}
-					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$page_end.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$page_end.', Math.max(0, page))+\'\'">...</a>]';
-					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$page_end.'"'.$pageNext.'>'.$page_end.'</a>] ';
+					$pte_vals['{$PAGENAV}'] .= '[<a onclick="var page=prompt(\'Jump to page: (1-'.$len.')\', 1);if(page != null) document.location=\''.PHP_SELF.'?page_num=\'+Math.min('.$len.', Math.max(0, page))+\'\'">...</a>]';
+					$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$len.'"'.$pageNext.'>'.$len.'</a>] ';
 				}
-			}
+			}			
 			
 			
 			

--- a/pixmicat.php
+++ b/pixmicat.php
@@ -220,7 +220,9 @@ function updatelog($resno=0,$page_num=-1,$single_page=false){
 			//...
 			$pte_vals['{$PAGENAV}'] .= '[<a onclick="">...</a>]';
 			//最後三頁
+			
 			for($i = $page_end-3; $i < $page_end; $i++){
+				$pageNext = ($i==$next) ? ' rel="next"' : '';
 				if($adminMode || (STATIC_HTML_UNTIL != -1 && $i > STATIC_HTML_UNTIL ))$pte_vals['{$PAGENAV}'] .= '[<a href="'.PHP_SELF.'?page_num='.$i.'"'.$pageNext.'>'.$i.'</a>] ';
 			}
 			


### PR DESCRIPTION
Before:
{"posts":[{"no":8962786,"resto":8962683,"sub":"\u7121\u984c"...
After:
{"posts":[{"no":8962786,"resto":8962683,"sub":"無題"...