### PR TITLE
Fix: postform缺少</div>導致隱藏表單功能不正常

### DIFF
--- a/inc_pixmicat.tpl
+++ b/inc_pixmicat.tpl
@@ -76,7 +76,7 @@ var ext="{$ALLOW_UPLOAD_EXT}".toUpperCase().split("|");
 
 </form>
 <!--&IF($FORMBOTTOM,'{$FORMBOTTOM}','')-->
-
+</div>
 <!--/&POSTFORM-->
 <!--&FOOTER-->
 <div id="footer">


### PR DESCRIPTION
直接clone下來執行後發現隱藏表單功能會連底下討論串都隱藏，
檢查後發現inc_pixmicat.tpl裡面postform少了一個\</div>